### PR TITLE
Add transfer logic and tests

### DIFF
--- a/controllers/v1/transactions/transferController.js
+++ b/controllers/v1/transactions/transferController.js
@@ -1,13 +1,17 @@
+const { processTransfer } = require('../../../models/transferModel');
 const transferController = (req, res) => {
     const { accountId } = req.params;
-    const { destinationIban, amount } = req.body;
-    // IBAN validation and transfer logic
-    /*const isIbanValid = validateIban(destinationIban);
-    if (!isIbanValid) {
-        return res.status(400).json({ error: 'Invalid IBAN' });
-    }*/
+    const { amount, cardId, bankId, destinationIban } = req.body;
 
-    res.json({ message: `Successfully transferred ${amount} from account ${accountId} to ${destinationIban}` });
+    const result = processTransfer(accountId, amount, cardId, bankId, destinationIban);
+
+    if (result.error) {
+        return res.status(400).json({ error: result.error });
+    }
+
+    return res.status(200).json({
+        message: result.message,
+        newBalance: result.newBalance
+    });
 };
-
 module.exports = transferController;

--- a/models/transferModel.js
+++ b/models/transferModel.js
@@ -1,0 +1,76 @@
+// Example accounts with bank, card IDs, and balance
+let accounts = [
+    { accountId: '123456789', cardIds: ['1111', '2222'], bank: 'bankA', balance: 1000, iban: 'GB29NWBK60161331926819' },
+    { accountId: '987654321', cardIds: ['3333'], bank: 'bankB', balance: 500, iban: 'GB29NWBK60161331926820' },
+    { accountId: '112233445', cardIds: ['4444'], bank: 'bankA', balance: 700, iban: 'GB29NWBK60161331926821' },
+];
+
+const isValidIban = (iban) => {
+    // Regular expression to check if IBAN matches the pattern
+    const ibanRegex = /^[A-Z]{2}[0-9]{2}[A-Z0-9]{4,30}$/;
+    return ibanRegex.test(iban);
+};
+const processTransfer = (accountId, amount, cardId, bankId, destinationIban) => {
+    if (amount <= 0) {
+        return { error: 'Amount must be greater than 0' };
+    }
+
+    const sourceAccount = accounts.find(acc => acc.accountId === accountId);
+    if (!sourceAccount) {
+        return { error: 'Source account not found' };
+    }
+
+    if (!sourceAccount.cardIds.includes(cardId)) {
+        return { error: 'Card does not belong to source account' };
+    }
+
+    if (sourceAccount.bank !== bankId) {
+        return { error: 'BankId is from a different bank' };
+    }
+
+    // Validate destination IBAN
+    if (!isValidIban(destinationIban)) {
+        return { error: 'Invalid destination IBAN' };
+    }
+
+    // Check if source account has enough balance
+    if (sourceAccount.balance < amount) {
+        return { error: 'Insufficient funds for transfer' };
+    }
+
+    // Find the destination account by IBAN
+    const destinationAccount = accounts.find(acc => acc.iban === destinationIban);
+    if (!destinationAccount) {
+        return { error: 'Destination account not found' };
+    }
+
+    // Handle commission for transfers to different banks
+    const commission = sourceAccount.bank !== destinationAccount.bank ? 2 : 0;
+
+    // Total amount including commission
+    const totalAmount = amount + commission;
+
+    // Ensure the source account has enough funds for the total amount (including commission)
+    if (sourceAccount.balance < totalAmount) {
+        return { error: 'Insufficient funds after commission' };
+    }
+
+    // Perform the transfer: deduct amount from source account and add amount to destination account
+    sourceAccount.balance -= totalAmount;
+    destinationAccount.balance += amount;
+
+    return {
+        message: `Successfully transferred ${amount} from account ${accountId} to ${destinationIban}. Commission: ${commission}`,
+        newSourceBalance: sourceAccount.balance,
+        newDestinationBalance: destinationAccount.balance
+    };
+};
+const resetAccounts = () => {
+    accounts = [
+        { accountId: '123456789', cardIds: ['1111', '2222'], bank: 'bankA', balance: 1000, iban: 'GB29NWBK60161331926819' },
+        { accountId: '987654321', cardIds: ['3333'], bank: 'bankB', balance: 500, iban: 'GB29NWBK60161331926820' },
+        { accountId: '112233445', cardIds: ['4444'], bank: 'bankA', balance: 700, iban: 'GB29NWBK60161331926821' },
+    ]
+};
+
+module.exports = { processTransfer, resetAccounts };

--- a/models/transferModel.test.js
+++ b/models/transferModel.test.js
@@ -1,0 +1,66 @@
+const { processTransfer, resetAccounts } = require('./transferModel'); // Adjust the import based on the file path
+
+describe('processTransfer', () => {
+
+    beforeEach(() => {
+        // Reset accounts before each test to ensure a clean state
+        resetAccounts();
+    });
+
+    test('should transfer money successfully between accounts of the same bank', () => {
+        const result = processTransfer('123456789', 200, '1111', 'bankA', 'GB29NWBK60161331926821');
+
+        expect(result.error).toBeUndefined();  // No error should occur
+        expect(result.message).toBe('Successfully transferred 200 from account 123456789 to GB29NWBK60161331926821. Commission: 0');
+        expect(result.newSourceBalance).toBe(800); // Source account balance after transfer
+        expect(result.newDestinationBalance).toBe(900); // Destination account balance after transfer
+    });
+
+    test('should return an error if source account is not found', () => {
+        const result = processTransfer('000000000', 200, '1111', 'bankA', 'GB29NWBK60161331926821');
+
+        expect(result.error).toBe('Source account not found');
+    });
+
+    test('should return an error if card does not belong to the source account', () => {
+        const result = processTransfer('123456789', 200, '9999', 'bankA', 'GB29NWBK60161331926821');
+
+        expect(result.error).toBe('Card does not belong to source account');
+    });
+
+    test('should return an error if the bank ID is from a different bank', () => {
+        const result = processTransfer('123456789', 200, '1111', 'bankB', 'GB29NWBK60161331926821');
+
+        expect(result.error).toBe('BankId is from a different bank');
+    });
+
+    test('should return an error if destination IBAN is invalid', () => {
+        const result = processTransfer('123456789', 200, '1111', 'bankA', 'INVALIDIBAN123');
+
+        expect(result.error).toBe('Invalid destination IBAN');
+    });
+
+    test('should return an error if source account has insufficient funds for the transfer', () => {
+        const result = processTransfer('123456789', 1200, '1111', 'bankA', 'GB29NWBK60161331926821');
+
+        expect(result.error).toBe('Insufficient funds for transfer');
+    });
+
+    test('should return an error if source account has insufficient funds after commission', () => {
+        // Transfer between different banks with a commission
+        const result = processTransfer('123456789', 1000, '1111', 'bankA', 'GB29NWBK60161331926820');
+
+        expect(result.error).toBe('Insufficient funds after commission');
+    });
+
+    test('should successfully transfer money between accounts of different banks and apply commission', () => {
+        const result = processTransfer('123456789', 200, '1111', 'bankA', 'GB29NWBK60161331926820');
+
+        expect(result.error).toBeUndefined();  // No error should occur
+        expect(result.message).toBe('Successfully transferred 200 from account 123456789 to GB29NWBK60161331926820. Commission: 2');
+        expect(result.newSourceBalance).toBe(798); // Source account balance after transfer and commission
+        expect(result.newDestinationBalance).toBe(700); // Destination account balance after transfer
+    });
+
+});
+

--- a/schemas/v1/transferSchema.js
+++ b/schemas/v1/transferSchema.js
@@ -1,15 +1,24 @@
 const Joi = require('joi');
 
 const transferSchema = Joi.object({
-    destinationIban: Joi.string().length(22).required().messages({
-        'string.base': 'Destination IBAN must be a string.',
-        'string.length': 'IBAN must have exactly 22 characters.',
-        'any.required': 'Destination IBAN is required.',
-    }),
     amount: Joi.number().positive().required().messages({
         'number.base': 'Amount must be a number.',
         'number.positive': 'Amount must be greater than 0.',
         'any.required': 'Amount is required.',
+    }),
+    cardId: Joi.string().length(4).pattern(/^[0-9]+$/).required().messages({
+        'string.base': 'Card number must be a string.',
+        'string.length': 'Card number must be exactly 4 digits.',
+        'string.pattern.base': 'Card number must only contain digits.',
+        'any.required': 'Card number is required.',
+    }),
+    bankId: Joi.string().required().messages({
+        'any.required': '"bankId" is required'
+    }),
+    destinationIban: Joi.string().length(22).required().messages({
+        'string.base': 'Destination IBAN must be a string.',
+        'string.length': 'IBAN must have exactly 22 characters.',
+        'any.required': 'Destination IBAN is required.',
     }),
 });
 


### PR DESCRIPTION
### Description
This pull request introduces a simple money transfer logic for verifying deposits based on card ownership and ATM bank affiliation. The logic checks if the provided cardNumber belongs to the account, and if the ATM is from the same bank as the account before allowing a deposit.

- Account Validation: The account is found using accountId. If no matching account is found, it returns a 404 error with the message "Account not found."
- Card Validation: The cardNumber is validated against the list of cardIds associated with the account. If the card does not belong to the account, it returns a 400 error with the message "Card does not belong to this account."
- ATM Bank Validation: The provided atmBank is validated against the bank associated with the account. If they do not match, it returns a 400 error with the message "ATM is from a different bank."
- Deposit Logic: If both validations pass, the deposit is successfully processed by updating the account balance with the given amount. A success message is returned with the new balance.

